### PR TITLE
feat: Add Kasm workspace configuration for EmulatorJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Base image
+FROM lscr.io/linuxserver/emulatorjs:latest
+
+# Environment variables
+ENV PUID=1000
+ENV PGID=1000
+ENV TZ=Etc/UTC
+ENV SUBFOLDER=/
+
+# Expose ports
+EXPOSE 3000
+EXPOSE 80
+EXPOSE 4001
+
+# Define volume mappings (documentation purposes)
+VOLUME /config
+VOLUME /data
+
+# Note: restart: unless-stopped is a runtime flag, not set in Dockerfile
+# Kasm should be configured to handle this.
+
+# Default command (inherited from base image, but can be overridden if needed)
+# CMD ["/init"]


### PR DESCRIPTION
This commit introduces a Dockerfile to define a Kasm workspace for EmulatorJS.

The workspace is based on the `lscr.io/linuxserver/emulatorjs:latest` image. It exposes the necessary ports:
- 3000: Backend/management interface
- 80: Frontend emulation interface
- 4001: Optional IPFS peering

Environment variables (PUID, PGID, TZ, SUBFOLDER) are defined as per the EmulatorJS documentation. Volume mappings for `/config` and `/data` are also defined to ensure data persistence for user profiles, ROMs, and artwork.

I built and tested the image, confirming that the backend and frontend are accessible and that volume mappings work correctly. You will need to interact further within a browser environment for initial setup (downloading art/configs) and ROM management.